### PR TITLE
markdown の改行まわりをCSSでwork around

### DIFF
--- a/components/articleOfMarkdown.tsx
+++ b/components/articleOfMarkdown.tsx
@@ -19,7 +19,7 @@ export default function ArticleOfMarkdown (props: Props) {
 
   return (
     <article className={styles.article}>
-      <ReactMarkdown children={markdown} />
+      <ReactMarkdown children={markdown} className="line-break" />
     </article>
   )
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -2,9 +2,9 @@ import { Html, Head, Main, NextScript } from 'next/document'
 import MyHeader from '../components/myheader'
 import Script from 'next/script'
 import React from 'react'
-import { measurementId } from '../libs/firebase'
 
 const GoogleAnalytics = () => {
+  const measurementId = 'G-WK4056L7VX'
   if (process.env.NODE_ENV === 'production') {
     return (
         <React.Fragment>

--- a/pages/api/contents.tsx
+++ b/pages/api/contents.tsx
@@ -11,8 +11,8 @@ export default function Contents (req: NextApiRequest, res: NextApiResponse) {
   const contents: ContentApi[] = [
     {
       path: '/blog/review-of-as-internet',
-      title: '今さら『インターネット的』を読んだ話',
-      date: new Date('2023-1-1').toLocaleDateString('ja-JP'),
+      title: '今さら『インターネット的』を読んで、今さら個人サイトを作った話',
+      date: new Date('2023-1-18').toLocaleDateString('ja-JP'),
       genre: 'blog'
     }
   ]

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -59,3 +59,19 @@ a {
   margin-block-end: 0.83em;
   font-size: 1.2rem;
 }
+
+.line-break {
+  white-space: pre-line;
+}
+
+.line-break p,
+.line-break h1,
+.line-break h2,
+.line-break h3,
+.line-break h4 {
+  margin-block-end: 0;
+}
+
+.line-break p {
+  margin-block-start: 0;
+}


### PR DESCRIPTION
markdown の改行まわりをCSSでwork around

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/kitadakyou/kitadakyou.com/pull/33).
* #34
* __->__ #33
